### PR TITLE
Add missing dependencies for Debian-based installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PDF Redact Tools is a set of tools to help with securely redacting and stripping
 
 Here's how to package and install pdf-redact tools in Debian, Ubuntu, Mint, etc.:
 
-    sudo apt-get install imagemagick libimage-exiftool-perl
+    sudo apt-get install imagemagick libimage-exiftool-perl python-stdeb python-all
     ./build_deb.sh
     sudo dpkg -i deb_dist/pdf-redact-tools_0.1-1_all.deb
 


### PR DESCRIPTION
I had some difficulties installing pdf-redact-tools on my Mint machine because I was missing the [python-stdeb](https://packages.debian.org/wheezy/python-stdeb) and [python-all](https://packages.debian.org/wheezy/python-all) packages. This Pull Request updates the Debian-based installation instructions to include these packages.

This might also fix the problem mentioned in issue #4 
