### PR TITLE
fix build requirements for TAILS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ cd pdf-redact-tools
 Install dependencies:
 
 ```sh
-sudo apt-get install imagemagick libimage-exiftool-perl python-stdeb python-all
+sudo apt-get install imagemagick libimage-exiftool-perl python-stdeb python-all fakeroot build-essential
 ```
 
 Create a .deb and install it:


### PR DESCRIPTION
Hi @micahflee, we (@lucyparsonslabs @chicagolug) noticed that pdf-redact-tools wasn't building in TAILS. I'm not sure about fakeroot but definitely build-essential is needed, I suspect you installed build-essential many years ago and forgot about it. 