### PR TITLE
Reject filenames that begin with "-"

### DIFF
--- a/pdf-redact-tools
+++ b/pdf-redact-tools
@@ -165,6 +165,11 @@ def parse_arguments():
     return args
 
 def valid_pdf(filename):
+    # Reject filenames that start with '-', to avoid ImageMagick command injection
+    if filename.startswith('-'):
+        return False
+
+    # Make sure the file's mime type is 'application/pdf'
     return subprocess.check_output(['file',
         '-b',
         '--mime-type',


### PR DESCRIPTION
Because the filename that gets passed into `pdf-redact-tools` then gets passed into ImageMagick's `convert`, it's possible that a filename beginning with `-` could lead to command injection by specifying args to `convert`.

Even before this patch, this doesn't seem exploitable because argparse already rejects filenames that start with `-`:

```
$ ./pdf-redact-tools -s "-example.pdf"
usage: pdf-redact-tools [-h] (-e filename | -m filename | -s filename) [-a]
pdf-redact-tools: error: argument -s/--sanitize: expected one argument
```

But just in case someone could figure out how to specify a filename that begins with a `-`, this patch will validate against it.