### PR TITLE
Add instructions on how to install on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ $ sudo apt-get update
 $ sudo apt-get install pdf-redact-tools
 ```
 
+### FreeBSD
+
+```sh
+$ pkg install pdf-redact-tools
+```
+
 ### Other
 
 PDF Redact Tools isn't yet packaged in any GNU/Linux distributions yet, however it's easy to install by following the [build instructions](/BUILD.md). I haven't attempted to make this work in Windows.


### PR DESCRIPTION
pdf-redact-tools has been ported for FreeBSD. Add instructions on how to install.

References:
https://www.freshports.org/print/pdf-redact-tools/
https://svnweb.freebsd.org/ports/head/print/pdf-redact-tools/