### PR TITLE
Add Python 3 support

### DIFF
--- a/pdf-redact-tools
+++ b/pdf-redact-tools
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import print_function
 import sys, os, subprocess, argparse, shutil
 
 class PDFRedactTools(object):
@@ -39,18 +40,18 @@ class PDFRedactTools(object):
 
     def explode(self, achromatic = False):
         if not self.pdf_filename:
-            print 'Error: you must call set_pdf_filename before calling explode'
+            print('Error: you must call set_pdf_filename before calling explode')
             return False
 
         # make dir for pages
         if os.path.isdir(self.pages_dirname):
-            print 'Error: the directory {} already exists, you must delete it before exploding'.format(self.pages_dirname)
+            print('Error: the directory {} already exists, you must delete it before exploding'.format(self.pages_dirname))
             return False
         else:
-            os.makedirs(self.pages_dirname, 0700)
+            os.makedirs(self.pages_dirname, 0o700)
 
         # convert PDF to PNGs
-        print 'Converting PDF to PNGs'
+        print('Converting PDF to PNGs')
         subprocess.call([ 'convert',
             '-density', '128',
             self.pdf_filename,
@@ -59,7 +60,7 @@ class PDFRedactTools(object):
             self.transparent_filename])
 
         # flatten all the PNGs, so they don't have transparent backgrounds
-        print 'Flattening PNGs'
+        print('Flattening PNGs')
         filenames = os.listdir(self.pages_dirname)
         for filename in filenames:
             if os.path.splitext(filename)[1].lower() == '.png':
@@ -78,7 +79,7 @@ class PDFRedactTools(object):
 
         # convert images to achromatic to remove printer dots
         if achromatic:
-            print 'Converting colors to achromatic'
+            print('Converting colors to achromatic')
             filenames = os.listdir(self.pages_dirname)
             for filename in filenames:
                 if os.path.splitext(filename)[1].lower() == '.png':
@@ -114,22 +115,22 @@ class PDFRedactTools(object):
 
     def merge(self):
         if not self.pdf_filename:
-            print 'Error: you must call set_pdf_filename before calling merge'
+            print('Error: you must call set_pdf_filename before calling merge')
             return False
 
         # make sure pages directory exists
         if not os.path.isdir(self.pages_dirname):
-            print "Error: {} is not a directory".format(pages_dirname)
+            print("Error: {} is not a directory".format(pages_dirname))
             return False
 
         # convert PNGs to PDF
-        print "Converting PNGs to PDF"
+        print("Converting PNGs to PDF")
         subprocess.call(['convert',
             os.path.join(self.pages_dirname, 'page-*.png'),
             self.output_filename])
 
         # strip metadata
-        print "Stripping ImageMagick metadata"
+        print("Stripping ImageMagick metadata")
         subprocess.call(['exiftool', '-Title=', '-Producer=', self.output_filename])
         os.remove('{0}_original'.format(self.output_filename))
 
@@ -173,7 +174,7 @@ def valid_pdf(filename):
     return subprocess.check_output(['file',
         '-b',
         '--mime-type',
-        filename]).strip() == 'application/pdf'
+        filename]).decode().strip() == 'application/pdf'
 
 
 def main():
@@ -191,18 +192,18 @@ def main():
         if valid_pdf(explode_filename):
             pdfrt.set_pdf_filename(explode_filename)
             if pdfrt.explode(achromatic):
-                print 'All done, now go edit PNGs in {} to redact and then run: pdf-redact-tools -m {}'.format(pdfrt.pages_dirname, pdfrt.pdf_filename)
+                print('All done, now go edit PNGs in {} to redact and then run: pdf-redact-tools -m {}'.format(pdfrt.pages_dirname, pdfrt.pdf_filename))
         else:
-            print explode_filename,' does not appear to be a PDF file, will not process'
+            print(explode_filename,' does not appear to be a PDF file, will not process')
 
     # merge
     if merge_filename:
         if valid_pdf(merge_filename):
             pdfrt.set_pdf_filename(merge_filename)
             if pdfrt.merge():
-                print "All done, your final output is {}".format(pdfrt.output_filename)
+                print("All done, your final output is {}".format(pdfrt.output_filename))
         else:
-            print merge_filename,' does not appear to be a PDF file, will not process'
+            print(merge_filename,' does not appear to be a PDF file, will not process')
 
     # sanitize
     if sanitize_filename:
@@ -213,9 +214,9 @@ def main():
                     # delete temp files
                     shutil.rmtree(pdfrt.pages_dirname)
 
-                    print "All done, your final output is {}".format(pdfrt.output_filename)
+                    print("All done, your final output is {}".format(pdfrt.output_filename))
         else:
-            print sanitize_filename,' does not appear to be a PDF file, will not process'
+            print(sanitize_filename,' does not appear to be a PDF file, will not process')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This was intially generated by the automatic `2to3` converter, and then
cleaned up by hand. It should be fully compatible with both Python 2.7
and Python 3+ (I tested on both).

print() is now a function, octal literals need an 'o' in them, and
subprocess.check_output() returns bytes, which needs to be decoded into
a str before comparison.

----

Python 2 goes EOL in a little over 6 months (<https://pythonclock.org/>), so I thought it would be a good time to add Python 3 support :)