### PR TITLE
Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ cd pdf-redact-tools
 Install dependencies:
 
 ```sh
-sudo apt-get install imagemagick libimage-exiftool-perl python-stdeb python-all fakeroot build-essential
+sudo apt-get install imagemagick libimage-exiftool-perl python-stdeb python-all dh-python fakeroot build-essential 
 ```
 
 Create a .deb and install it:


### PR DESCRIPTION
Without dh-python:
➜  pdf-redact-tools  git:(master) ./build_deb.sh
rm: cannot remove 'deb_dist': No such file or directory
running bdist_deb
running sdist_dsc
running sdist
running check
warning: sdist: standard file not found: should have one of README, README.txt

reading manifest template 'MANIFEST.in'
writing manifest file 'MANIFEST'
creating pdf-redact-tools-0.1.2
making hard links in pdf-redact-tools-0.1.2...
hard linking LICENSE -> pdf-redact-tools-0.1.2
hard linking README.md -> pdf-redact-tools-0.1.2
hard linking pdf-redact-tools -> pdf-redact-tools-0.1.2
hard linking setup.py -> pdf-redact-tools-0.1.2
hard linking version -> pdf-redact-tools-0.1.2
creating dist
Creating tar archive
removing 'pdf-redact-tools-0.1.2' (and everything under it)
CALLING dpkg-source -b pdf-redact-tools-0.1.2 pdf-redact-tools_0.1.2.orig.tar.gz (in dir deb_dist)
dpkg-source: info: using source format '3.0 (quilt)'
dpkg-source: info: building pdf-redact-tools using existing ./pdf-redact-tools_0.1.2.orig.tar.gz
dpkg-source: info: building pdf-redact-tools in pdf-redact-tools_0.1.2-1.debian.tar.xz
dpkg-source: info: building pdf-redact-tools in pdf-redact-tools_0.1.2-1.dsc
dpkg-buildpackage: info: source package pdf-redact-tools
dpkg-buildpackage: info: source version 0.1.2-1
dpkg-buildpackage: info: source distribution trusty
dpkg-buildpackage: info: source changed by Micah Lee <micah.lee@firstlook.org>
 dpkg-source --before-build pdf-redact-tools-0.1.2
dpkg-checkbuilddeps: error: Unmet build dependencies: dh-python
dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
dpkg-buildpackage: warning: (Use -d flag to override.)
Traceback (most recent call last):
  File "setup.py", line 17, in <module>
    scripts=['pdf-redact-tools']
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/dist-packages/stdeb/command/bdist_deb.py", line 22, in run
    self.run_command('sdist_dsc')
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/dist-packages/stdeb/command/sdist_dsc.py", line 140, in run
    remove_expanded_source_dir=self.remove_expanded_source_dir,
  File "/usr/lib/python2.7/dist-packages/stdeb/util.py", line 1397, in build_dsc
    dpkg_genchanges(cwd=fullpath_repackaged_dirname)
  File "/usr/lib/python2.7/dist-packages/stdeb/util.py", line 538, in dpkg_genchanges
    process_command(args,cwd=cwd)
  File "/usr/lib/python2.7/dist-packages/stdeb/util.py", line 183, in process_command
    check_call(args, cwd=cwd)
  File "/usr/lib/python2.7/dist-packages/stdeb/util.py", line 46, in check_call
    raise CalledProcessError(retcode)
stdeb.util.CalledProcessError: 3

To install, run:
sudo dpkg -i deb_dist/pdf-redact-tools_0.1.2-1_all.deb